### PR TITLE
Add missing env cleanup and key validator prototypes

### DIFF
--- a/V1/SRC/built/echo/echo.h
+++ b/V1/SRC/built/echo/echo.h
@@ -12,6 +12,7 @@ int builtin_echo(t_shell *shell, char **argv);
 
 char *get_dollar_value(const char *arg, int *pos, t_shell *sh);
 char *replace_variables(const char *arg, t_shell *sh);
+int is_valid_key_char(char c);
 
 #endif
     

--- a/V1/SRC/handle_utils/util-3-free.c
+++ b/V1/SRC/handle_utils/util-3-free.c
@@ -80,6 +80,11 @@ void free_list_str(t_list *lst)
         lst = tmp;
     }
 }
+
+void free_env(t_list *env)
+{
+    free_list_str(env);
+}
 void free_str_array(char **arr)
 {
     if (!arr) {

--- a/V2/SRC/built/echo/echo.h
+++ b/V2/SRC/built/echo/echo.h
@@ -12,6 +12,7 @@ int builtin_echo(t_shell *shell, char **argv);
 
 char *get_dollar_value(const char *arg, int *pos, t_shell *sh);
 char *replace_variables(const char *arg, t_shell *sh);
+int is_valid_key_char(char c);
 
 #endif
     

--- a/V2/SRC/built/echo/echo_value.c
+++ b/V2/SRC/built/echo/echo_value.c
@@ -36,7 +36,7 @@ static char *get_special_var(const char *key)
     return NULL;
 }
 
-static int is_valid_key_char(char c)
+int is_valid_key_char(char c)
 {
     return (ft_isalnum(c) || c == '_');
 }

--- a/V2/SRC/handle_utils/util-3-free.c
+++ b/V2/SRC/handle_utils/util-3-free.c
@@ -80,6 +80,11 @@ void free_list_str(t_list *lst)
         lst = tmp;
     }
 }
+
+void free_env(t_list *env)
+{
+    free_list_str(env);
+}
 void free_str_array(char **arr)
 {
     if (!arr) {


### PR DESCRIPTION
## Summary
- declare `is_valid_key_char` in echo headers and expose implementation
- add `free_env` helper to free environment list and avoid leaks

## Testing
- `make minishell`
- `./minishell <<'EOF'
exit
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6899faf1ed1c8329a3ce84507db96a75