### PR TITLE
Fix echo execution and memory cleanup in minishell v2

### DIFF
--- a/V2/SRC/handle_utils/util-3-free.c
+++ b/V2/SRC/handle_utils/util-3-free.c
@@ -156,7 +156,6 @@ void free_tokens(t_shell *shell)
             }
             free(tok->cmd_args_parts);
             if (tok->value) {
-                free(tok->value);
                 tok->value = NULL;
             }
             

--- a/V2/SRC/parser/costum_split.c
+++ b/V2/SRC/parser/costum_split.c
@@ -210,26 +210,28 @@ t_arr 	*custom_split(const char *str, t_shell * shell)
 	if (!result)
 		perror("Malloc");
 	result->len = count_arg(str, shell); //have to implemente the <quote> if " or ' not closed
-	result->arr = malloc(sizeof(char *) * (result->len));
-	if (!result->arr)
-	{
-		free(result);
-		perror("Malloc");
-	}
+        result->arr = malloc(sizeof(char *) * (result->len + 1));
+        if (!result->arr)
+        {
+                free(result);
+                perror("Malloc");
+        }
 	pos = 0;
 	token_index = 0;
-	while (token_index < result->len)
-	{
-		result->arr[token_index] = extract_arg(str, &pos, shell); //, &arr_token[token_index]);
-		if (!result->arr[token_index])
-		{
-			for (int i = 0; i < token_index; i++)
-				free(result->arr[i]);
-			free(result->arr);
-			free(result);
-			perror("Erreur d'allocation pour les tokens");
-		}
-		token_index++;
-	}
-	return result;
+        while (token_index < result->len)
+        {
+                result->arr[token_index] = extract_arg(str, &pos, shell); //, &arr_token[token_index]);
+                if (!result->arr[token_index])
+                {
+                        for (int i = 0; i < token_index; i++)
+                                free(result->arr[i]);
+                        free(result->arr);
+                        free(result);
+                        perror("Erreur d'allocation pour les tokens");
+                        return NULL;
+                }
+                token_index++;
+        }
+        result->arr[token_index] = NULL;
+        return result;
 }

--- a/V2/SRC/parser/launch.c
+++ b/V2/SRC/parser/launch.c
@@ -46,8 +46,11 @@ int start_cmd(t_shell *shell, int *prev_pipe, int *curr_pipe)
     if (pid == 0)
     {
         add_pid_env(shell,fd_pid[0]);
-        dup2(shell->fd_in, STDIN_FILENO);
-        close(shell->fd_in);
+        if (shell->fd_in != STDIN_FILENO)
+        {
+            dup2(shell->fd_in, STDIN_FILENO);
+            close(shell->fd_in);
+        }
         dup2(curr_pipe[1], STDOUT_FILENO);
         close(curr_pipe[0]);
         close(curr_pipe[1]);
@@ -89,8 +92,11 @@ int end_cmd(t_shell *shell,int *prev_pipe)
         dup2(prev_pipe[0], STDIN_FILENO);
         close(prev_pipe[0]);
         close(prev_pipe[1]);
-        dup2(shell->fd_out, STDOUT_FILENO);
-        close(shell->fd_out);
+        if (shell->fd_out != STDOUT_FILENO)
+        {
+            dup2(shell->fd_out, STDOUT_FILENO);
+            close(shell->fd_out);
+        }
         execute(shell,shell->cmd_tail->content);
     }
     send_pid(fd_pid[1],pid);
@@ -128,19 +134,22 @@ void one_command(t_shell *shell)
     
     if (pid == 0)
     {
-        int d; //debug
-        scanf("%d", &d); // debug
-        
         close(fd[1]);
-        close(fd_pid[0]);  
+        close(fd_pid[0]);
         add_pid_env(shell,fd_pid[0]);
         close(fd[0]);
         close(fd_pid[0]);
 
-        dup2(shell->fd_in, STDIN_FILENO);
-        close(shell->fd_in);
-        dup2(shell->fd_out, STDOUT_FILENO);
-        close(shell->fd_out);
+        if (shell->fd_in != STDIN_FILENO)
+        {
+            dup2(shell->fd_in, STDIN_FILENO);
+            close(shell->fd_in);
+        }
+        if (shell->fd_out != STDOUT_FILENO)
+        {
+            dup2(shell->fd_out, STDOUT_FILENO);
+            close(shell->fd_out);
+        }
         execute(shell, shell->cmd_head->content);
         exit(1);
     }

--- a/V2/SRC/parser/lexer.c
+++ b/V2/SRC/parser/lexer.c
@@ -84,7 +84,7 @@ int attribute_cmd_subtokens(t_shell *shell, t_token *cmd_token, int idx, int len
 	t_arr *arr_arg = shell->parsed_args;
 	char *curr_arg;
 	int idx_container = 0;
-	cmd_token->cmd_args_parts = malloc(sizeof(t_subtoken_container *)*len);
+        cmd_token->cmd_args_parts = malloc(sizeof(t_subtoken_container) * len);
 	arr_container = cmd_token->cmd_args_parts;
 	if (!arr_container)
 		return -1;


### PR DESCRIPTION
## Summary
- prevent stdin/stdout from being closed during command execution and remove leftover debug wait
- allocate parser token arrays correctly and null-terminate splits
- avoid invalid frees when cleaning tokens

## Testing
- `./minishell <<'EOF'
echo test
echo "$PWD"
echo '$PWD'
ls
exit
EOF`


------
https://chatgpt.com/codex/tasks/task_e_689a1984fd8883298d9bdd39601694b6