### PR TITLE
Fix export invalid identifier error handling

### DIFF
--- a/V1/SRC/built/export/export_args.c
+++ b/V1/SRC/built/export/export_args.c
@@ -22,7 +22,8 @@ int handle_arg_with_assignment(char *arg, t_shell *shell)
     *eq = '\0';
     if (!is_valid_identifier(arg))
     {
-        printf("minishell: export: `%s': not a valid identifier\n", arg);
+        fprintf(stderr, "minishell: export: `%s': not a valid identifier\n", arg);
+        shell->exit_status = 1;
         ret = 1;
     }
     else if (set_env_var(shell, arg, eq + 1) != 0)
@@ -36,7 +37,8 @@ int handle_arg_without_assignment(char *arg, t_shell *shell)
 {
     if (!is_valid_identifier(arg))
     {
-        printf("minishell: export: `%s': not a valid identifier\n", arg);
+        fprintf(stderr, "minishell: export: `%s': not a valid identifier\n", arg);
+        shell->exit_status = 1;
         return 1;
     }
     if (!find_env_var(shell, arg))


### PR DESCRIPTION
## Summary
- Print export invalid identifier errors to stderr
- Propagate exit status when export argument is invalid

## Testing
- `make minishell LDFLAGS="-lreadline -no-pie"`

------
https://chatgpt.com/codex/tasks/task_e_689a2515dca0832980ea9f43eb662116