### PR TITLE
Implement input and output redirection

### DIFF
--- a/V2/SRC/handle_utils/handler_operator/handler-2.c
+++ b/V2/SRC/handle_utils/handler_operator/handler-2.c
@@ -3,26 +3,62 @@
 
 int handle_pipe(t_shell *shell, char **argv)
 {
-    (void) shell;
-    (void) argv; // Suppress unused parameter warning
+    (void)shell;
+    (void)argv;
     printf("Handling PIPE (|)\n");
-    // TODO: Implement pipe logic
-    return 0;
+    return (0);
 }
+
+static int  open_infile(t_shell *shell, const char *path)
+{
+    int fd;
+
+    fd = open(path, O_RDONLY);
+    if (fd < 0)
+    {
+        perror(path);
+        return (1);
+    }
+    if (shell->fd_in != STDIN_FILENO && shell->fd_in != -1)
+        close(shell->fd_in);
+    shell->fd_in = fd;
+    return (0);
+}
+
 int handle_redirect_in(t_shell *shell, char **argv)
 {
-    (void) shell;
-    (void) argv; // Suppress unused parameter warning
-    printf("Handling REDIRECT_IN (<)\n");
-    // TODO: Implement input redirection logic
-    return 0;
+    if (!argv || !argv[1])
+    {
+        ft_putendl_fd("minishell: syntax error near unexpected token `newline'",
+            STDERR_FILENO);
+        return (1);
+    }
+    return (open_infile(shell, argv[1]));
 }
+
+static int  open_outfile(t_shell *shell, const char *path, int flags)
+{
+    int fd;
+
+    fd = open(path, flags, 0644);
+    if (fd < 0)
+    {
+        perror(path);
+        return (1);
+    }
+    if (shell->fd_out != STDOUT_FILENO && shell->fd_out != -1)
+        close(shell->fd_out);
+    shell->fd_out = fd;
+    return (0);
+}
+
 int handle_redirect_out(t_shell *shell, char **argv)
 {
-    (void) shell;
-    (void) argv; // Suppress unused parameter warning
-    printf("Handling REDIRECT_OUT (>)\n");
-    // TODO: Implement output redirection logic
-    return 0;
-
+    if (!argv || !argv[1])
+    {
+        ft_putendl_fd("minishell: syntax error near unexpected token `newline'",
+            STDERR_FILENO);
+        return (1);
+    }
+    return (open_outfile(shell, argv[1], O_CREAT | O_TRUNC | O_WRONLY));
 }

--- a/V3/SRC/handle_utils/handler_operator/handler-2.c
+++ b/V3/SRC/handle_utils/handler_operator/handler-2.c
@@ -3,26 +3,62 @@
 
 int handle_pipe(t_shell *shell, char **argv)
 {
-    (void) shell;
-    (void) argv; // Suppress unused parameter warning
+    (void)shell;
+    (void)argv;
     printf("Handling PIPE (|)\n");
-    // TODO: Implement pipe logic
-    return 0;
+    return (0);
 }
+
+static int  open_infile(t_shell *shell, const char *path)
+{
+    int fd;
+
+    fd = open(path, O_RDONLY);
+    if (fd < 0)
+    {
+        perror(path);
+        return (1);
+    }
+    if (shell->fd_in != STDIN_FILENO && shell->fd_in != -1)
+        close(shell->fd_in);
+    shell->fd_in = fd;
+    return (0);
+}
+
 int handle_redirect_in(t_shell *shell, char **argv)
 {
-    (void) shell;
-    (void) argv; // Suppress unused parameter warning
-    printf("Handling REDIRECT_IN (<)\n");
-    // TODO: Implement input redirection logic
-    return 0;
+    if (!argv || !argv[1])
+    {
+        ft_putendl_fd("minishell: syntax error near unexpected token `newline'",
+            STDERR_FILENO);
+        return (1);
+    }
+    return (open_infile(shell, argv[1]));
 }
+
+static int  open_outfile(t_shell *shell, const char *path, int flags)
+{
+    int fd;
+
+    fd = open(path, flags, 0644);
+    if (fd < 0)
+    {
+        perror(path);
+        return (1);
+    }
+    if (shell->fd_out != STDOUT_FILENO && shell->fd_out != -1)
+        close(shell->fd_out);
+    shell->fd_out = fd;
+    return (0);
+}
+
 int handle_redirect_out(t_shell *shell, char **argv)
 {
-    (void) shell;
-    (void) argv; // Suppress unused parameter warning
-    printf("Handling REDIRECT_OUT (>)\n");
-    // TODO: Implement output redirection logic
-    return 0;
-
+    if (!argv || !argv[1])
+    {
+        ft_putendl_fd("minishell: syntax error near unexpected token `newline'",
+            STDERR_FILENO);
+        return (1);
+    }
+    return (open_outfile(shell, argv[1], O_CREAT | O_TRUNC | O_WRONLY));
 }


### PR DESCRIPTION
## Summary
- open input files for `<` and replace existing `fd_in`
- open output files for `>` with truncation and update `fd_out`

## Testing
- `cd V2 && make minishell` *(fails: relocation R_X86_64_32S can not be used when making a PIE object)*
- `cd V3 && make minishell`

------
https://chatgpt.com/codex/tasks/task_e_689a34f5fad48329a7b71d8b7edc9df9