### PR TITLE
refactor: store environment as structured list

### DIFF
--- a/V1/SRC/built/echo/echo_value.c
+++ b/V1/SRC/built/echo/echo_value.c
@@ -15,12 +15,11 @@ static char *find_env_value(t_list *env_list, const char *key)
 }*/
 char *find_env_value(t_list *env, const char *key)
 {
-    size_t keylen = ft_strlen(key);
     while (env)
     {
-        char *entry = (char *)env->content;
-        if (ft_strncmp(entry, key, keylen) == 0 && entry[keylen] == '=')
-            return entry + keylen + 1;
+        t_env *entry = env->content;
+        if (ft_strcmp(entry->key, key) == 0)
+            return entry->value;
         env = env->next;
     }
     return NULL;

--- a/V1/SRC/built/env.c
+++ b/V1/SRC/built/env.c
@@ -64,10 +64,9 @@ int builtin_env(t_shell *shell, char **args)
     t_list *cur = shell->env;
     while (cur)
     {
-        // On n’affiche que les entrées contenant '='
-        char *entry = (char *)cur->content;
-        if (ft_strchr(entry, '=')) // Affiche seulement si c'est une vraie variable d'env
-            printf("%s\n", entry);
+        t_env *env = cur->content;
+        if (env->value)
+            printf("%s=%s\n", env->key, env->value);
         cur = cur->next;
     }
     shell->exit_status = 0;

--- a/V1/SRC/built/export/export.c
+++ b/V1/SRC/built/export/export.c
@@ -350,7 +350,8 @@ void print_env_debug(t_list *env)
 {
     while (env)
     {
-        printf("[DEBUG] %s\n", (char*)env->content);
+        t_env *e = env->content;
+        printf("[DEBUG] %s=%s\n", e->key, e->value ? e->value : "");
         env = env->next;
     }
 }

--- a/V1/SRC/built/export/export.h
+++ b/V1/SRC/built/export/export.h
@@ -27,6 +27,6 @@ t_list *find_env_var(t_shell *shell, const char *key);
 int update_env_var(t_list *env, const char *value);
 int create_env_var(t_shell *shell, const char *key, const char *value);
 int set_env_var(t_shell *shell, const char *key, const char *value);
-char *create_env_entry(char *env_line);
+char *create_env_entry(t_env *env);
 
 #endif

--- a/V1/SRC/built/export/export_env.c
+++ b/V1/SRC/built/export/export_env.c
@@ -1,9 +1,4 @@
 #include "export.h"
-typedef struct s_env
-{
-    char *key;
-    char *value;
-} t_env;
 
 t_list *find_env_var(t_shell *shell, const char *key)
 {

--- a/V1/SRC/built/export/export_utils.c
+++ b/V1/SRC/built/export/export_utils.c
@@ -13,30 +13,22 @@ size_t env_count(t_shell *shell)
     return count;
 }
 
-// Si tu stockes des char* dans content
-char *create_env_entry(char *env_line)
-{
-    return ft_strdup(env_line);
-}
-
-/**
-char *create_env_entry(t_list *env)
+char *create_env_entry(t_env *env)
 {
     size_t klen = ft_strlen(env->key);
     size_t vlen = env->value ? ft_strlen(env->value) : 0;
     char *entry = malloc(klen + vlen + 2);
-    if (!entry) return NULL;
+    if (!entry)
+        return NULL;
 
     ft_strcpy(entry, env->key);
+    entry[klen] = '=';
     if (env->value)
-    {
-        entry[klen] = '=';
         ft_strcpy(entry + klen + 1, env->value);
-    }
-    else entry[klen] = '\0';
-
+    else
+        entry[klen + 1] = '\0';
     return entry;
-}**/
+}
 
 char **env_to_array(t_shell *shell)
 {
@@ -47,8 +39,8 @@ char **env_to_array(t_shell *shell)
     size_t i = 0;
     for (t_list *node = shell->env; node; node = node->next)
     {
-        t_list *env = (t_list *)node->content;
-        arr[i] = create_env_entry((char*)env->content);
+        t_env *env = (t_env *)node->content;
+        arr[i] = create_env_entry(env);
         if (!arr[i])
         {
             free_export_arr(arr);

--- a/V1/SRC/built/unset.c
+++ b/V1/SRC/built/unset.c
@@ -6,24 +6,26 @@
 
 static void unset_one(t_list **env, const char *key)
 {
-    t_list *prev = NULL, *cur = *env;
+    t_list *prev = NULL;
+    t_list *cur = *env;
+
     while (cur)
     {
-        char *equal = strchr((char*)cur->content, '=');
-        if (equal)
+        t_env *env_var = cur->content;
+        if (ft_strcmp(env_var->key, key) == 0)
         {
-            size_t key_len = strlen(key);
-            if ((size_t)(equal - (char*)cur->content) == key_len && !strncmp((char*)cur->content, key, key_len))
-            {
-                if (prev) prev->next = cur->next;
-                else      *env = cur->next;
-                free(cur->content);
-                free(cur);
-                return;
-            }
+            if (prev)
+                prev->next = cur->next;
+            else
+                *env = cur->next;
+            free(env_var->key);
+            free(env_var->value);
+            free(env_var);
+            free(cur);
+            return;
         }
         prev = cur;
-        cur  = cur->next;
+        cur = cur->next;
     }
 }
 
@@ -41,20 +43,21 @@ int builtin_unset(t_shell *shell, char **argv)
 }
 void unset_env_value(t_list **env, const char *key)
 {
-    t_list *tmp = *env, *prev = NULL;
-    size_t key_len = ft_strlen(key);
+    t_list *tmp = *env;
+    t_list *prev = NULL;
 
     while (tmp)
     {
-        char *content = (char*)tmp->content;
-        char *equal = ft_strchr(content, '=');
-        if (equal && (size_t)(equal - content) == key_len && !ft_strncmp(content, key, key_len))
+        t_env *env_var = tmp->content;
+        if (ft_strcmp(env_var->key, key) == 0)
         {
             if (prev)
                 prev->next = tmp->next;
             else
                 *env = tmp->next;
-            free(tmp->content);
+            free(env_var->key);
+            free(env_var->value);
+            free(env_var);
             free(tmp);
             return;
         }

--- a/V1/SRC/env/env_list.c
+++ b/V1/SRC/env/env_list.c
@@ -1,176 +1,103 @@
-/* ************************************************************************** */
-/*                                                                            */
-/*                                                        :::      ::::::::   */
-/*   env_list.c                                         :+:      :+:    :+:   */
-/*                                                    +:+ +:+         +:+     */
-/*   By: nkiefer <nkiefer@student.42.fr>            +#+  +:+       +#+        */
-/*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2025/06/12 16:35:29 by eganassi          #+#    #+#             */
-/*   Updated: 2025/07/14 18:28:31 by nkiefer          ###   ########.fr       */
-/*                                                                            */
-/* ************************************************************************** */
-
 #include "../../include/minishell.h"
-
 #include <stdlib.h>
 
 int env_len(t_list *env)
 {
-	int count = 0;
+    int count = 0;
 
-	while (env)
-	{
-		count++;
-		env = env->next;
-	}
-	return count;
-}
-
-/*
-char	**env_to_envp(t_env *env)
-{
-    t_env	*curr;
-    int		count = 0;
-    char	**envp;
-    int		i;
-
-    curr = env;
-    while (curr)
+    while (env)
     {
         count++;
-        curr = curr->next;
+        env = env->next;
     }
-    envp = malloc(sizeof(char *) * (count + 1));
-    if (!envp)
-        handle_error("malloc");
-    i = 0;
-    curr = env;
-    while (curr)
-    {
-        envp[i] = ft_strjoin_3(curr->key, "=", curr->value);
-        i++;
-        curr = curr->next;
-    }
-    envp[i] = NULL;
-    return (envp);
-}*/
-
-// parse la string "KEY=VALUE" en t_env
-// Dans ton create_env (ou équivalent) :
-/*
-t_env	*create_env(char *env_str)
-{
-	t_env	*node;
-	char	*equal;
-	size_t	key_len;
-
-	node = malloc(sizeof(t_env));
-	if (!node)
-		return (NULL);
-	equal = ft_strchr(env_str, '=');
-	if (!equal)
-	{
-		free(node);
-		return (NULL);
-	}
-	key_len = equal - env_str;
-	node->key = malloc(key_len + 1);
-	if (!node->key)
-	{
-		free(node);
-		return (NULL);
-	}
-	if (ft_strlcpy(node->key, env_str, key_len + 1) != key_len)
-		handle_error("ft_strlcpy error copying key");
-	node->value = ft_strdup(equal + 1);
-	node->next = NULL;
-	return (node);
-}*//*
-t_env	*create_env(const char *key, const char *value)
-{
-	t_env	*node;
-
-	node = malloc(sizeof(t_env));
-	if (!node)
-		return (NULL);
-	node->key = ft_strdup(key);
-	if (!node->key)
-	{
-		free(node);
-		return (NULL);
-	}
-	node->value = ft_strdup(value);
-	if (!node->value)
-	{
-		free(node->key);
-		free(node);
-		return (NULL);
-	}
-	node->next = NULL;
-	return (node);
+    return count;
 }
 
-char **env_to_envp(t_env *env)
+char **env_to_envp(t_list *env)
 {
-    int count = env_len(env);
-    char **envp = malloc(sizeof(char *) * (count + 1));
-    t_env *curr = env;
-    int i = 0;
+    int     count = env_len(env);
+    char    **envp = malloc(sizeof(char *) * (count + 1));
+    int     i = 0;
+
     if (!envp)
         return NULL;
-    while (curr)
+    while (env)
     {
-        int keylen = ft_strlen(curr->key);
-        int vallen = ft_strlen(curr->value);
-        envp[i] = malloc(keylen + 1 + vallen + 1); // key + '=' + value + '\0'
+        t_env *cur = env->content;
+        int klen = ft_strlen(cur->key);
+        int vlen = cur->value ? ft_strlen(cur->value) : 0;
+        envp[i] = malloc(klen + 1 + vlen + 1);
         if (!envp[i])
         {
-            // clean up before return !
-            for (int j = 0; j < i; ++j) free(envp[j]);
+            while (i > 0)
+                free(envp[--i]);
             free(envp);
             return NULL;
         }
-        ft_strcpy(envp[i], curr->key);
-        envp[i][keylen] = '=';
-        ft_strcpy(envp[i] + keylen + 1, curr->value);
+        ft_strcpy(envp[i], cur->key);
+        envp[i][klen] = '=';
+        if (cur->value)
+            ft_strcpy(envp[i] + klen + 1, cur->value);
+        else
+            envp[i][klen + 1] = '\0';
+        env = env->next;
         i++;
-        curr = curr->next;
     }
     envp[i] = NULL;
     return envp;
-}*/
+}
 
 void print_env(t_list *env)
 {
     while (env)
     {
-        printf("%s\n", (char*)env->content);
+        t_env *cur = env->content;
+        if (cur->value)
+            printf("%s=%s\n", cur->key, cur->value);
+        else
+            printf("%s=\n", cur->key);
         env = env->next;
     }
 }
 
-
 t_list *init_env(char **envp)
 {
-    t_list *head = NULL, *new = NULL;
-    int i = 0;
+    t_list *head = NULL;
+    t_list *tail = NULL;
+    int     i = 0;
 
     while (envp[i])
     {
-        new = malloc(sizeof(t_list));
-        if (!new)
-            return NULL;
-        new->content = strdup(envp[i]);   // Copie "KEY=VALUE"
-        new->next = NULL;
-        if (!head)
-            head = new;
-        else
+        char *eq = ft_strchr(envp[i], '=');
+        t_env *env;
+        t_list *node;
+
+        if (!eq)
         {
-            t_list *tmp = head;
-            while (tmp->next)
-                tmp = tmp->next;
-            tmp->next = new;
+            i++;
+            continue;
         }
+        env = malloc(sizeof(t_env));
+        if (!env)
+            return NULL;
+        env->key = ft_substr(envp[i], 0, eq - envp[i]);
+        env->value = ft_strdup(eq + 1);
+        node = malloc(sizeof(t_list));
+        if (!node || !env->key || !env->value)
+        {
+            free(env->key);
+            free(env->value);
+            free(env);
+            free(node);
+            return NULL;
+        }
+        node->content = env;
+        node->next = NULL;
+        if (!head)
+            head = node;
+        else
+            tail->next = node;
+        tail = node;
         i++;
     }
     return head;

--- a/V1/include/minishell.h
+++ b/V1/include/minishell.h
@@ -43,6 +43,12 @@ typedef struct s_list
     struct s_list   *next;
 }   t_list;
 
+typedef struct s_env
+{
+    char    *key;
+    char    *value;
+}   t_env;
+
 typedef struct s_arr
 {
     void            **arr;


### PR DESCRIPTION
## Summary
- keep environment entries as dedicated `t_env` nodes
- rework env initialization and export/unset logic to use structured env
- adjust env lookup helpers for variable expansion

## Testing
- `cd V1 && make re`

------
https://chatgpt.com/codex/tasks/task_e_689a34c1dfe88329a662c8d823b93423