### PR TITLE
Ensure export modifies environment in V1

### DIFF
--- a/V1/SRC/parser/launch.c
+++ b/V1/SRC/parser/launch.c
@@ -233,6 +233,25 @@ void launch_process(t_shell *shell)
     int      prev_fd  = -1;
     int      pipe_fd[2];
 
+    /* Exécuter un builtin sans forker s'il est seul */
+    if (shell->n_cmd == 1)
+    {
+        char **args = expand_cmd((t_token *)curr_cmd->content, shell->env);
+        if (args)
+        {
+            int idx = is_in_t_arr_str(shell->bcmd, args[0]);
+            if (idx != -1)
+            {
+                int (*handler)(t_shell *, char **) = get_builtin_handler(shell->bcmd, idx);
+                if (handler)
+                    shell->exit_status = handler(shell, args);
+                free_tab(args);
+                return;
+            }
+            free_tab(args);
+        }
+    }
+
     for (int i = 0; i < shell->n_cmd; i++)
     {
         /* Si ce n'est pas la dernière commande, on crée un pipe */

--- a/V1/SRC/parser/path.c
+++ b/V1/SRC/parser/path.c
@@ -358,7 +358,7 @@ void execute_cmd(t_shell *shell, t_token *cmd)
     }
 
     /* 3) Préparation de l'envp et exec */
-    envp = linked_to_array_string(shell->env);
+    envp = env_to_envp(shell->env);
     execve(cmd_path, args, envp);
 
     /* 4) Si execve échoue, afficher l’erreur et cleanup */

--- a/V1/SRC/parser/t_list.c
+++ b/V1/SRC/parser/t_list.c
@@ -124,24 +124,6 @@ char **linked_to_array_string(t_list *node)
     arr[len] = NULL;
     return arr;
 }*/
-char **linked_to_array_string(t_list *node)
-{
-    int len = 0;
-    t_list *tmp = node;
-    while (tmp) { len++; tmp = tmp->next; }
-    char **arr = malloc(sizeof(char *) * (len + 1));
-    int i = 0;
-    tmp = node;
-    while (tmp)
-    {
-        arr[i++] = ft_strdup(tmp->content);
-        tmp = tmp->next;
-    }
-    arr[i] = NULL;
-    return arr;
-}
-
-
 void ft_lstadd_front(t_list **lst, void *content)
 {
     t_list *new_node;

--- a/V1/include/minishell.h
+++ b/V1/include/minishell.h
@@ -212,7 +212,9 @@ void    free_list_str(t_list *lst);
 void    push_lst(t_list **lst, void *content);
 
 char    *ft_strdup_count(const char *src, int *count);
-char    **linked_to_array_string(t_list *env);
+
+char    **expand_cmd(t_token *token, t_list *env);
+int (*get_builtin_handler(t_arr *bcmd, int idx))(t_shell *, char **);
 
 void free_str_array(char **arr);
 


### PR DESCRIPTION
## Summary
- pass shell environment to execve using `env_to_envp`
- run standalone builtins without forking so `export` updates persist
- expose `expand_cmd`/`get_builtin_handler` prototypes and drop unused env array helper

## Testing
- `make`
- `./minishell <<'EOF'
export TEST=1
env | grep TEST
exit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_689a3f6f310883299361b205d65ca07d