### PR TITLE
Fix pipeline fd handling and env output

### DIFF
--- a/V1/SRC/built/env.c
+++ b/V1/SRC/built/env.c
@@ -1,74 +1,36 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   env.c                                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: nkiefer <nkiefer@student.42.fr>            +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/08/18 00:00:00 by chatgpt           #+#    #+#             */
+/*   Updated: 2025/08/18 00:00:00 by chatgpt          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
 #include "../../include/minishell.h"
-
-
-/*
-char **env_to_envp(t_env *env)
-{
-	int count = env_len(env); // à coder si besoin
-	char **envp = malloc(sizeof(char *) * (count + 1));
-	int i = 0;
-
-	while (env)
-	{
-		envp[i] = ft_strjoin_3(env->key, "=", env->value); // "VAR=VALUE"
-		if (!envp[i])
-			return (NULL); // gestion à améliorer
-		env = env->next;
-		i++;
-	}
-	envp[i] = NULL;
-	return envp;
-}
-char **env_to_envp(t_env *env)
-{
-	int count = env_len(env);
-	char **envp = malloc(sizeof(char *) * (count + 1));
-	int i = 0;
-
-	if (!envp)
-		handle_error("malloc");
-
-	while (env)
-	{
-		envp[i] = ft_strjoin3(env->key, "=", env->value, 1); // "VAR=VALUE"
-		if (!envp[i])
-		{
-			// libère les précédents
-			while (--i >= 0)
-				free(envp[i]);
-			free(envp);
-			return (NULL);
-		}
-		env = env->next;
-		i++;
-	}
-	envp[i] = NULL;
-	return envp;
-}
-
-
-
-void print_env(t_env *env)
-{
-    while (env)
-    {
-        printf("%s=%s\n", env->key, env->value);
-        env = env->next;
-    }
-}
-*/
 
 int builtin_env(t_shell *shell, char **args)
 {
+    t_list  *cur;
+    t_env   *env;
+
     (void)args;
-    t_list *cur = shell->env;
+    cur = shell->env;
     while (cur)
     {
-        t_env *env = cur->content;
+        env = cur->content;
         if (env->value)
-            printf("%s=%s\n", env->key, env->value);
+        {
+            write(STDOUT_FILENO, env->key, ft_strlen(env->key));
+            write(STDOUT_FILENO, "=", 1);
+            write(STDOUT_FILENO, env->value, ft_strlen(env->value));
+            write(STDOUT_FILENO, "\n", 1);
+        }
         cur = cur->next;
     }
     shell->exit_status = 0;
-    return 0;
+    return (0);
 }

--- a/V1/SRC/env/env_list.c
+++ b/V1/SRC/env/env_list.c
@@ -3,48 +3,58 @@
 
 int env_len(t_list *env)
 {
-    int count = 0;
+    int count;
 
+    count = 0;
     while (env)
     {
         count++;
         env = env->next;
     }
-    return count;
+    return (count);
 }
 
-char **env_to_envp(t_list *env)
+char    **list_to_envp(t_list *env)
 {
-    int     count = env_len(env);
-    char    **envp = malloc(sizeof(char *) * (count + 1));
-    int     i = 0;
+    int     count;
+    int     i;
+    char    **envp;
+    t_env   *cur;
+    int     klen;
+    int     vlen;
 
+    count = 0;
+    for (t_list *it = env; it; it = it->next)
+        if (((t_env *)it->content)->value)
+            count++;
+    envp = malloc(sizeof(char *) * (count + 1));
     if (!envp)
-        return NULL;
+        return (NULL);
+    i = 0;
     while (env)
     {
-        t_env *cur = env->content;
-        int klen = ft_strlen(cur->key);
-        int vlen = cur->value ? ft_strlen(cur->value) : 0;
-        envp[i] = malloc(klen + 1 + vlen + 1);
-        if (!envp[i])
-        {
-            while (i > 0)
-                free(envp[--i]);
-            free(envp);
-            return NULL;
-        }
-        ft_strcpy(envp[i], cur->key);
-        envp[i][klen] = '=';
+        cur = env->content;
         if (cur->value)
+        {
+            klen = ft_strlen(cur->key);
+            vlen = ft_strlen(cur->value);
+            envp[i] = malloc(klen + 1 + vlen + 1);
+            if (!envp[i])
+            {
+                while (i > 0)
+                    free(envp[--i]);
+                free(envp);
+                return (NULL);
+            }
+            ft_strcpy(envp[i], cur->key);
+            envp[i][klen] = '=';
             ft_strcpy(envp[i] + klen + 1, cur->value);
-        else
-            envp[i][klen + 1] = '\0';
+            i++;
+        }
         env = env->next;
-        i++;
     }
     envp[i] = NULL;
-    return envp;
+    return (envp);
 }
 
 void print_env(t_list *env)

--- a/V1/SRC/main/main_loop.c
+++ b/V1/SRC/main/main_loop.c
@@ -213,10 +213,7 @@ int looping(t_shell *shell)
         /* Attribution des types */
         attribute_token_type(shell);
 
-        /* Reset & fallback commande unique */
-        shell->n_cmd   = 0;
-        shell->cmd_head = NULL;
-        shell->cmd_tail = NULL;
+        build_cmd_list(shell);
         if (shell->n_tokens > 0 && shell->n_cmd == 0)
         {
             shell->n_cmd = 1;

--- a/V1/SRC/parser/launch.c
+++ b/V1/SRC/parser/launch.c
@@ -290,13 +290,15 @@ void launch_process(t_shell *shell)
 
         /* ——— Le PARENT ——— */
         shell->pids[i] = pid;
+        if (prev_fd != -1)
+            close(prev_fd);
         if (i < shell->n_cmd - 1)
         {
             close(pipe_fd[1]);
-            if (prev_fd != -1)
-                close(prev_fd);
             prev_fd = pipe_fd[0];
         }
+        else
+            prev_fd = -1;
         curr_cmd = curr_cmd->next;
     }
 

--- a/V1/SRC/parser/lexer.c
+++ b/V1/SRC/parser/lexer.c
@@ -119,9 +119,32 @@ void file_access_redirection(t_shell *shell, void **arr, int t_arr_index, int i)
 		if (access(arr[i + 1], O_CREAT | O_RDWR | O_APPEND | O_TRUNC) < 0)
 			perror("Erreur lors de l'ouverture en écriture (append)");
 	}
-	else if (t_arr_index == 6)
-	{
-		if (access(arr[i + 1], O_CREAT | O_RDWR | O_TRUNC) < 0)
-			perror("Erreur lors de l'ouverture en écriture (trunc)");
-	}
+        else if (t_arr_index == 6)
+        {
+                if (access(arr[i + 1], O_CREAT | O_RDWR | O_TRUNC) < 0)
+                        perror("Erreur lors de l'ouverture en écriture (trunc)");
+        }
 }
+
+void    build_cmd_list(t_shell *shell)
+{
+    int i;
+
+    shell->cmd_head = NULL;
+    shell->cmd_tail = NULL;
+    shell->n_cmd = 0;
+    if (!shell->tokens)
+        return ;
+    i = 0;
+    while (i < shell->n_tokens)
+    {
+        if (shell->tokens[i].type == TOKEN_CMD
+            || shell->tokens[i].type == TOKEN_BCMD)
+        {
+            add_cmd(shell, &shell->tokens[i]);
+            shell->n_cmd++;
+        }
+        i++;
+    }
+}
+

--- a/V1/SRC/parser/path.c
+++ b/V1/SRC/parser/path.c
@@ -337,15 +337,11 @@ void execute_cmd(t_shell *shell, t_token *cmd)
     if (idx != -1)
     {
         int (*handler)(t_shell *, char **) = get_builtin_handler(shell->bcmd, idx);
-        //printf("DEBUG handler=%p idx=%d\n", handler, idx);
-		//printf("[CALL] handler=%p for %s\n", handler, args[0]);
-
-		if (handler)
+        if (handler)
         {
             shell->exit_status = handler(shell, args);
-            exit_shell(shell, shell->exit_status);
+            _exit(shell->exit_status);
         }
-        // En cas d’imprévu
         child_exit(args, NULL, NULL, NULL, 1);
     }
 
@@ -358,7 +354,7 @@ void execute_cmd(t_shell *shell, t_token *cmd)
     }
 
     /* 3) Préparation de l'envp et exec */
-    envp = env_to_envp(shell->env);
+    envp = list_to_envp(shell->env);
     execve(cmd_path, args, envp);
 
     /* 4) Si execve échoue, afficher l’erreur et cleanup */

--- a/V1/SRC/parser/tool_lexer.c
+++ b/V1/SRC/parser/tool_lexer.c
@@ -102,35 +102,32 @@ int count_subtokens(const char *str)
  * ============================= */
 int count_tokens(t_shell *shell, t_arr *parsed_args, t_arr *oper)
 {
-    int count = 1;
-    int i = 0;
-    int len;
+    int count;
+    int i;
     int idx_oper;
+    int n_args;
 
     if (!parsed_args || !parsed_args->arr)
         return 0;
-
-    len = parsed_args->len;
-    if (len == 0)
-        return 0;
-
-    while (i < len)
+    count = 0;
+    i = 0;
+    while (i < parsed_args->len)
     {
         idx_oper = is_in_t_arr_dic_str(oper, parsed_args->arr[i]);
         if (idx_oper != -1)
         {
+            count++;
             if (idx_oper < 2 || idx_oper > 4)
-            {
-                file_access_redirection(shell, parsed_args->arr, idx_oper, i);
                 i += 2;
-                continue;
-            }
             else
-            {
-                count++;
-            }
+                i++;
         }
-        i++;
+        else
+        {
+            count++;
+            n_args = count_args_cmd(shell, i);
+            i += n_args;
+        }
     }
     return count;
 }

--- a/V1/include/minishell.h
+++ b/V1/include/minishell.h
@@ -164,7 +164,7 @@ int   export_no_arguments(t_shell *shell);
 int   process_export_argument(char *arg, t_shell *shell);
 /* --- Env --- */
 char    *get_env_value(t_list *env, const char *name);
-char    **env_to_envp(t_list *env);
+char    **list_to_envp(t_list *env);
 int     env_len(t_list *env);
 void    print_env(t_list *env);
 t_list  *init_env(char **envp);
@@ -182,6 +182,7 @@ void    subtoken_of_cmd(t_subtoken_container *container, char *arg);
 int     find_c_nonescaped(const char *str, char *needle, int size_needle);
 bool    escape_check(const char *str, int idx);
 void    file_access_redirection(t_shell *shell, void **arr, int t_arr_index, int i);
+void    build_cmd_list(t_shell *shell);
 char *find_command_path(char *cmd, t_list *env);
 void     execute_cmd(t_shell *shell, t_token *cmd);
 //void     ft_itoa_inplace(char *buf, int n);


### PR DESCRIPTION
## Summary
- implement `builtin_env` that prints one variable per line
- convert environment list into `char **` with new `list_to_envp`
- ensure built-ins run in child processes and close pipeline FDs correctly
- parse command tokens into a pipeline-ready list before execution

## Testing
- `make minishell`
- `printf "b\na\nc\n" | sort`
- `printf "env | grep -v SHLVL | grep -v ^_\n" | ./minishell`
- `printf "env | sort | head\n" | ./minishell`


------
https://chatgpt.com/codex/tasks/task_e_689a497967048329953fa14023d33fec