### PR TITLE
feat: apply redirections before executing commands

### DIFF
--- a/V1/SRC/handle_utils/util-3-free.c
+++ b/V1/SRC/handle_utils/util-3-free.c
@@ -160,6 +160,13 @@ void free_tokens(t_shell *shell)
             
           //  printf("[DEBUG] free_tokens 156: freed cmd_args_parts of token '%s'\n", tok->value);
         }
+        if (tok->r)
+        {
+            for (int j = 0; j < tok->r_count; j++)
+                free(tok->r[j].arg);
+            free(tok->r);
+            tok->r = NULL;
+        }
         // Si value = strdup/ft_substr => free, sinon ne pas toucher
         // (mais dans ton parsing c’est souvent juste un pointeur du split, donc ne rien faire)
     }

--- a/V1/SRC/main/main_loop.c
+++ b/V1/SRC/main/main_loop.c
@@ -212,6 +212,7 @@ int looping(t_shell *shell)
 
         /* Attribution des types */
         attribute_token_type(shell);
+        assign_redirs(shell);
 
         build_cmd_list(shell);
         if (shell->n_tokens > 0 && shell->n_cmd == 0)

--- a/V1/SRC/parser/launch.c
+++ b/V1/SRC/parser/launch.c
@@ -101,9 +101,14 @@ int start_cmd(t_shell *shell, int *prev_pipe, int *curr_pipe, t_list *curr_cmd)
         close(curr_pipe[1]);
         close(shell->fd_pid[0]);
         close(shell->fd_pid[1]);
-        //execute(shell, curr_cmd->content);
-        execute_cmd(shell, (t_token *)curr_cmd->content);
-        exit(1);
+        t_token *tok = (t_token *)curr_cmd->content;
+        t_cmd    tmp = {0};
+        tmp.r = tok->r;
+        tmp.r_count = tok->r_count;
+        if (apply_redirs_in_child(&tmp, shell))
+            _exit(1);
+        execute_cmd(shell, tok);
+        _exit(1);
     }
 
     if (shell->fd_in != STDIN_FILENO)
@@ -141,9 +146,14 @@ int end_cmd(t_shell *shell, int *prev_pipe, t_list *curr_cmd)
 
         dup2(shell->fd_out, STDOUT_FILENO);
         close(shell->fd_out);
-        // Execute
-        execute_cmd(shell, (t_token *)curr_cmd->content);
-        exit(1);
+        t_token *tok = (t_token *)curr_cmd->content;
+        t_cmd    tmp = {0};
+        tmp.r = tok->r;
+        tmp.r_count = tok->r_count;
+        if (apply_redirs_in_child(&tmp, shell))
+            _exit(1);
+        execute_cmd(shell, tok);
+        _exit(1);
     }
     send_pid(shell->fd_pid[1], pid);
     close(shell->fd_pid[0]);
@@ -212,9 +222,14 @@ void one_command(t_shell *shell)
         dup2(shell->fd_out, STDOUT_FILENO);
         close(shell->fd_out);
        // execute_cmd(shell, shell->parser.cmd_head);
-        execute_cmd(shell, (t_token *)shell->cmd_head->content);
-        //execute(shell, shell->parser.cmd_head->content);
-        exit(1);
+        t_token *tok = (t_token *)shell->cmd_head->content;
+        t_cmd    tmp = {0};
+        tmp.r = tok->r;
+        tmp.r_count = tok->r_count;
+        if (apply_redirs_in_child(&tmp, shell))
+            _exit(1);
+        execute_cmd(shell, tok);
+        _exit(1);
     }
     else
     close(fd[0]);  // Close read end
@@ -284,8 +299,14 @@ void launch_process(t_shell *shell)
                 close(pipe_fd[0]);
                 close(pipe_fd[1]);
             }
-            execute_cmd(shell, (t_token *)curr_cmd->content);
-            exit(EXIT_FAILURE);
+            t_token *tok = (t_token *)curr_cmd->content;
+            t_cmd    tmp = {0};
+            tmp.r = tok->r;
+            tmp.r_count = tok->r_count;
+            if (apply_redirs_in_child(&tmp, shell))
+                _exit(1);
+            execute_cmd(shell, tok);
+            _exit(EXIT_FAILURE);
         }
 
         /* ——— Le PARENT ——— */

--- a/V1/include/minishell.h
+++ b/V1/include/minishell.h
@@ -99,6 +99,8 @@ typedef struct s_token
     t_subtoken_container    *cmd_args_parts;
     struct s_token          *next;
    int                     n_args;
+   t_redir                 *r;
+   int                     r_count;
 }   t_token;
 
 /* =============================
@@ -207,6 +209,7 @@ char    *find_env_value(t_list *env, const char *key);
 t_arr   *custom_split(const char *str, t_shell *shell);
 int     count_tokens(t_shell *shell, t_arr *parsed_args, t_arr *oper);
 void    attribute_token_type(t_shell *shell);
+void    assign_redirs(t_shell *shell);
 int     count_args_cmd(t_shell *shell, int i);
 int     attribute_cmd_subtokens(t_shell *shell, t_token *cmd_token, int idx, int len);
 int     count_subtokens(const char *str);


### PR DESCRIPTION
## Summary
- parse and attach redirection directives to each command token
- apply child redirections before invoking `execute_cmd`
- release redirection resources during token cleanup

## Testing
- `make -C V1`

------
https://chatgpt.com/codex/tasks/task_e_689a581a526c83299ce502ece3120fda