### PR TITLE
Implement pipeline execution logic

### DIFF
--- a/V1/SRC/parser/lexer.c
+++ b/V1/SRC/parser/lexer.c
@@ -38,6 +38,39 @@ void add_cmd(t_shell *shell, t_token *token)
     }
 }
 
+/*
+ * Build a linked list of command tokens from the array of tokens
+ * produced during parsing. Only command or builtin tokens are kept
+ * and the resulting list is stored in shell->cmd_head.
+ */
+void build_cmd_list(t_shell *shell)
+{
+    t_token *prev;
+    int     i;
+
+    if (!shell || !shell->tokens)
+        return ;
+    shell->cmd_head = NULL;
+    shell->cmd_tail = NULL;
+    shell->n_cmd = 0;
+    prev = NULL;
+    i = 0;
+    while (i < shell->n_tokens)
+    {
+        t_token *tok = &shell->tokens[i];
+        if (tok->type == TOKEN_CMD || tok->type == TOKEN_BCMD)
+        {
+            if (prev)
+                prev->next = tok;
+            tok->next = NULL;
+            add_cmd(shell, tok);
+            prev = tok;
+            shell->n_cmd++;
+        }
+        i++;
+    }
+}
+
 int count_args_cmd(t_shell *shell, int i)
 {
     int     n_args;

--- a/V1/SRC/pipe/pipe.c
+++ b/V1/SRC/pipe/pipe.c
@@ -1,0 +1,78 @@
+#include "../../include/minishell.h"
+
+/*
+ * Execute a pipeline of commands stored in shell->cmd_head.
+ * For each command we fork, redirect using dup2 and close
+ * unused descriptors in both parent and child processes.
+ */
+void    execute_pipeline(t_shell *shell)
+{
+    t_list  *curr;
+    int     prev_fd;
+    int     pipe_fd[2];
+    int     i;
+
+    curr = shell->cmd_head;
+    prev_fd = -1;
+    i = 0;
+    while (curr)
+    {
+        if (curr->next != NULL)
+        {
+            if (pipe(pipe_fd) == -1)
+            {
+                perror("pipe");
+                return ;
+            }
+        }
+        shell->pids[i] = fork();
+        if (shell->pids[i] < 0)
+        {
+            perror("fork");
+            return ;
+        }
+        if (shell->pids[i] == 0)
+        {
+            if (prev_fd != -1)
+            {
+                if (dup2(prev_fd, STDIN_FILENO) == -1)
+                    perror("dup2");
+                close(prev_fd);
+            }
+            if (curr->next != NULL)
+            {
+                if (dup2(pipe_fd[1], STDOUT_FILENO) == -1)
+                    perror("dup2");
+                close(pipe_fd[0]);
+                close(pipe_fd[1]);
+            }
+            execute_cmd(shell, (t_token *)curr->content);
+            exit(EXIT_FAILURE);
+        }
+        if (prev_fd != -1)
+            close(prev_fd);
+        if (curr->next != NULL)
+        {
+            close(pipe_fd[1]);
+            prev_fd = pipe_fd[0];
+        }
+        else
+            prev_fd = -1;
+        curr = curr->next;
+        i++;
+    }
+    // Parent waits for children and updates exit_status
+    int status;
+    while (--i >= 0)
+    {
+        waitpid(shell->pids[i], &status, 0);
+        if (i == 0)
+        {
+            if (WIFEXITED(status))
+                shell->exit_status = WEXITSTATUS(status);
+            else if (WIFSIGNALED(status))
+                shell->exit_status = 128 + WTERMSIG(status);
+        }
+    }
+}
+

--- a/V1/SRC/redir/advanced_redir.c
+++ b/V1/SRC/redir/advanced_redir.c
@@ -261,12 +261,7 @@ void child_exec_maillon(t_cmd *c, t_shell *sh, int i, int ncmd, int p[][2])
     if (c->is_builtin)
         _exit(run_builtin(c, sh));
 
-    char **envp = env_to_envp(sh->env);
-
-
-    //char **envp = list_to_envp(sh->env);
-
-
+    char **envp = list_to_envp(sh->env);
     execve(resolve_path(c->argv[0], sh), c->argv, envp);
     perror("execve");
     _exit(127);

--- a/V1/include/minishell.h
+++ b/V1/include/minishell.h
@@ -216,7 +216,6 @@ bool    escape_check(const char *str, int idx);
 
 //void    file_access_redirection(t_shell *shell, void **arr, int t_arr_index, int i);
 void    build_cmd_list(t_shell *shell);
-=======
 int     file_access_redirection(t_shell *shell, void **arr, int t_arr_index, int i);
 
 char *find_command_path(char *cmd, t_list *env);


### PR DESCRIPTION
## Summary
- add pipeline execution function creating pipes and forking each command
- ensure proper descriptor duplication and cleanup in child and parent processes
- build command list from tokens and fix env list conversion call

## Testing
- `cd V1 && make all >/tmp/make.log && tail -n 20 /tmp/make.log`


------
https://chatgpt.com/codex/tasks/task_e_689a580c66cc8329a7789f8dd4ae2044