### PR TITLE
Fix build errors in minishell

### DIFF
--- a/V1/Makefile
+++ b/V1/Makefile
@@ -23,11 +23,11 @@ CC           := cc
 
 # FLAGS POUR RELEASE (par défaut)
 
-RELEASE_FLAGS := -Wall -Wextra -Werror -no-pie $(ALL_PATHS)
+RELEASE_FLAGS := -Wall -Wextra -Werror $(ALL_PATHS)
 RELEASE_LDFLAGS := -lreadline -no-pie
 
 # FLAGS POUR DEBUG (avec AddressSanitizer & debug info)
-DEBUG_FLAGS := -g -fsanitize=address -fno-omit-frame-pointer -Wall -Wextra -Werror -no-pie $(ALL_PATHS)
+DEBUG_FLAGS := -g -fsanitize=address -fno-omit-frame-pointer -Wall -Wextra -Werror $(ALL_PATHS)
 
 
 DEBUG_LDFLAGS := -lreadline -fsanitize=address -no-pie

--- a/V1/include/minishell.h
+++ b/V1/include/minishell.h
@@ -92,6 +92,9 @@ typedef struct s_subtoken_container
     int             n_parts;
 }   t_subtoken_container;
 
+/* Forward declaration to allow pointers before full definition */
+typedef struct s_redir t_redir;
+
 typedef struct s_token
 {
     char                    type;


### PR DESCRIPTION
## Summary
- forward declare `t_redir` before `t_token` to resolve unknown type compilation error
- drop `-no-pie` from compile flags to avoid clang unused argument warnings

## Testing
- `make re`
- `echo -e "echo hi\nexit\n" | ./minishell`


------
https://chatgpt.com/codex/tasks/task_e_689a5d680500832986dee5e0329e9fe6