### PR TITLE
Handle attached redirection operators

### DIFF
--- a/V1/SRC/parser/costum_split.c
+++ b/V1/SRC/parser/costum_split.c
@@ -60,15 +60,27 @@ static char *extract_arg(const char *str, int *start, t_shell *shell)
     bool  in_double_quote = false;
     int   token_start = *start;
     int   token_end;
-    int   idx_oper_one;
-    int   oper_ad = 0;
+    int   idx_oper;
+    int   oper_len;
     char  *token;
 
-    // Skip espaces
     while (str[token_start] && str[token_start] == ' ')
         token_start++;
     if (!str[token_start])
         return NULL;
+
+    idx_oper = is_in_t_arr_dic_str(shell->oper, &str[token_start]);
+    if (idx_oper != -1)
+    {
+        oper_len = ft_strlen((const char *)((t_dic *)shell->oper->arr[idx_oper])->key);
+        token = malloc(oper_len + 1);
+        if (!token)
+            return NULL;
+        strncpy(token, str + token_start, oper_len);
+        token[oper_len] = '\0';
+        *start = token_start + oper_len;
+        return token;
+    }
 
     token_end = token_start;
     while (str[token_end])
@@ -79,23 +91,12 @@ static char *extract_arg(const char *str, int *start, t_shell *shell)
             in_double_quote = !in_double_quote;
         else if (!in_single_quote && !in_double_quote)
         {
-            if (str[token_end] == ' ')
+            if (str[token_end] == ' ' ||
+                is_in_t_arr_dic_str(shell->oper, &str[token_end]) != -1)
                 break;
-            idx_oper_one = is_in_t_arr_dic_str(shell->oper, &str[token_end]);
-            if (idx_oper_one != -1)
-            {
-                oper_ad = ft_strlen((const char *)((t_dic *)shell->oper->arr[idx_oper_one])->key);
-                break;
-            }
-            if (str[token_end + 1] && is_in_t_arr_dic_str(shell->oper, &str[token_end + 1]) != -1)
-            {
-                oper_ad = 1;
-                break;
-            }
         }
         token_end++;
     }
-    token_end += oper_ad;
     *start = token_end;
 
     token = malloc((token_end - token_start) + 1);

--- a/V1/tests/Makefile
+++ b/V1/tests/Makefile
@@ -1,0 +1,18 @@
+.RECIPEPREFIX := >
+CC=cc
+CFLAGS=-Wall -Wextra -Werror -I../include -I../include/LIBFT
+LDFLAGS=../include/LIBFT/libft.a -lcriterion
+SRC=test_custom_split.c ../SRC/parser/costum_split.c
+
+all: test
+
+test: $(SRC)
+>$(CC) $(CFLAGS) $(SRC) $(LDFLAGS) -o test
+
+run: test
+>./test
+
+clean:
+>rm -f test
+
+.PHONY: all run clean test

--- a/V1/tests/test_custom_split.c
+++ b/V1/tests/test_custom_split.c
@@ -1,0 +1,83 @@
+#include <criterion/criterion.h>
+#include "../include/minishell.h"
+#include <stdlib.h>
+#include <string.h>
+
+bool escape_check(const char *str, int idx)
+{
+    bool toggle = true;
+    while (idx > 0 && str[--idx] == '\\')
+        toggle = !toggle;
+    return toggle;
+}
+
+int is_in_t_arr_dic_str(t_arr *arr, const char *arg)
+{
+    if (!arr || !arr->arr || !arg)
+        return -1;
+    for (int i = 0; i < arr->len; i++)
+    {
+        t_dic *dic = (t_dic *)arr->arr[i];
+        if (dic && dic->key)
+        {
+            size_t len_key = ft_strlen(dic->key);
+            if (ft_strncmp(dic->key, arg, len_key) == 0)
+                return i;
+        }
+    }
+    return -1;
+}
+
+static t_shell init_shell(void)
+{
+    static t_dic in = {"<", NULL};
+    static t_dic out = {">", NULL};
+    static void *op_arr[] = {&in, &out};
+    static t_arr oper = {op_arr, 2};
+    t_shell shell = {0};
+    shell.oper = &oper;
+    return shell;
+}
+
+static void free_tokens_arr(t_arr *tokens)
+{
+    if (!tokens)
+        return;
+    for (int i = 0; i < tokens->len; i++)
+        free(tokens->arr[i]);
+    free(tokens->arr);
+    free(tokens);
+}
+
+Test(custom_split, redir_double_quotes_without_space)
+{
+    t_shell shell = init_shell();
+    t_arr *tokens = custom_split("<\"file\"", &shell);
+    cr_assert_not_null(tokens);
+    cr_assert_eq(tokens->len, 2);
+    cr_assert_str_eq(tokens->arr[0], "<");
+    cr_assert_str_eq(tokens->arr[1], "\"file\"");
+    free_tokens_arr(tokens);
+}
+
+Test(custom_split, redir_single_quotes_without_space)
+{
+    t_shell shell = init_shell();
+    t_arr *tokens = custom_split(">'file'", &shell);
+    cr_assert_not_null(tokens);
+    cr_assert_eq(tokens->len, 2);
+    cr_assert_str_eq(tokens->arr[0], ">");
+    cr_assert_str_eq(tokens->arr[1], "'file'");
+    free_tokens_arr(tokens);
+}
+
+Test(custom_split, redir_plain_without_space)
+{
+    t_shell shell = init_shell();
+    t_arr *tokens = custom_split(">outfile", &shell);
+    cr_assert_not_null(tokens);
+    cr_assert_eq(tokens->len, 2);
+    cr_assert_str_eq(tokens->arr[0], ">");
+    cr_assert_str_eq(tokens->arr[1], "outfile");
+    free_tokens_arr(tokens);
+}


### PR DESCRIPTION
## Summary
- Ensure `extract_arg` splits redirection operators from their arguments even when no space is present
- Add Criterion tests for redirections with double quotes, single quotes and no quotes

## Testing
- `cd V1/tests && make clean && make test`
- `cd V1/tests && ./test`


------
https://chatgpt.com/codex/tasks/task_e_689a6271a94c832992ec9104bfe981a8