### PR TITLE
Handle redirection file errors

### DIFF
--- a/V1/SRC/parser/lexer.c
+++ b/V1/SRC/parser/lexer.c
@@ -170,20 +170,43 @@ void assign_redirs(t_shell *shell)
         }
         else if (op_idx < 2 || op_idx > 4)
         {
+            char *op = ((t_dic *)shell->oper->arr[op_idx])->key;
+            char *fname;
+            if ((int)ft_strlen(arr[i]) > (int)ft_strlen(op))
+            {
+                fname = arr[i] + ft_strlen(op);
+                i++;
+            }
+            else
+            {
+                fname = arr[i + 1];
+                i += 2;
+            }
+            if (!fname || *fname == '\0')
+            {
+                ft_putstr_fd((char *)"minishell: missing file name for redirection\n", STDERR_FILENO);
+                shell->exit_status = 1;
+                shell->n_tokens = 0;
+                return;
+            }
+            int fd = -1;
+            if (op_idx == 5)
+                fd = open(fname, O_RDONLY);
+            else if (op_idx == 6)
+                fd = open(fname, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+            else if (op_idx == 1)
+                fd = open(fname, O_CREAT | O_WRONLY | O_APPEND, 0644);
+            if (fd < 0 && op_idx != 0)
+            {
+                perror(fname);
+                shell->exit_status = 1;
+                shell->n_tokens = 0;
+                return;
+            }
+            if (fd >= 0)
+                close(fd);
             if (current)
             {
-                char *op = ((t_dic *)shell->oper->arr[op_idx])->key;
-                char *fname;
-                if ((int)ft_strlen(arr[i]) > (int)ft_strlen(op))
-                {
-                    fname = arr[i] + ft_strlen(op);
-                    i++;
-                }
-                else
-                {
-                    fname = arr[i + 1];
-                    i += 2;
-                }
                 if (op_idx == 5)
                     add_redir(current, R_IN, fname);
                 else if (op_idx == 6)
@@ -193,8 +216,6 @@ void assign_redirs(t_shell *shell)
                 else if (op_idx == 0)
                     add_redir(current, R_HEREDOC, fname);
             }
-            else
-                i++;
         }
         else
         {

--- a/V1/tests/test_redirections.py
+++ b/V1/tests/test_redirections.py
@@ -1,0 +1,28 @@
+import os
+import subprocess
+from pathlib import Path
+import pytest
+
+BIN = str(Path(__file__).resolve().parents[1] / 'minishell')
+
+def run_ms(cmds: str):
+    return subprocess.run(BIN, input=cmds.encode(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+def test_missing_input_file():
+    proc = run_ms('cat < missing\nexit\n')
+    assert b'missing' in proc.stderr
+    assert proc.returncode == 1
+
+def test_output_invalid_permission():
+    os.makedirs('test_files', exist_ok=True)
+    path = Path('test_files/invalid_permission')
+    if path.exists():
+        if path.is_file():
+            path.unlink()
+        else:
+            os.rmdir(path)
+    path.mkdir()
+    os.chmod(path, 0o000)
+    proc = run_ms('echo test > ./test_files/invalid_permission\nexit\n')
+    assert (b'Permission denied' in proc.stderr) or (b'Is a directory' in proc.stderr)
+    assert proc.returncode == 1


### PR DESCRIPTION
## Summary
- validate redirection filenames before adding
- report file open errors and set exit status
- test missing input file and invalid output path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a627356ac8329b6d2885a4bee2a77